### PR TITLE
fix: Lock chart.js

### DIFF
--- a/packages/angular-charts/index.js
+++ b/packages/angular-charts/index.js
@@ -10,6 +10,7 @@ class AngularChartsTemplate extends TemplatePackage {
       '@angular/material': '~10.2.4',
       '@angular/cdk': '~10.2.4',
       'ngx-spinner': '^10.0.1',
+      'chart.js': '^2.9.4',
     };
   }
 }

--- a/packages/angular-test-charts/index.js
+++ b/packages/angular-test-charts/index.js
@@ -1,5 +1,11 @@
 const { TemplatePackage } = require('@cubejs-templates/core');
 
-class TestChartsTemplate extends TemplatePackage {}
+class TestChartsTemplate extends TemplatePackage {
+  importDependencies() {
+    return {
+      'chart.js': '^2.9.4',
+    };
+  }
+}
 
 module.exports = (context) => new TestChartsTemplate(context);

--- a/packages/ng2-charts/index.js
+++ b/packages/ng2-charts/index.js
@@ -3,7 +3,13 @@ const {
   QueryRendererSnippet,
 } = require('@cubejs-templates/core');
 
-class Ng2ChartsTemplate extends TemplatePackage {}
+class Ng2ChartsTemplate extends TemplatePackage {
+  importDependencies() {
+    return {
+      'chart.js': '^2.9.4',
+    };
+  }
+}
 
 module.exports = (context) =>
   new Ng2ChartsTemplate(context, {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/572096/130100653-731be925-8418-4508-bb73-78c0d145e065.png)

There is a problem with compatiblity between ng2-charts and chart.js