### PR TITLE
Support drill down on react chartjs charts

### DIFF
--- a/packages/chartjs-charts/scaffolding/src/components/ChartRenderer.js
+++ b/packages/chartjs-charts/scaffolding/src/components/ChartRenderer.js
@@ -144,6 +144,20 @@ const AreaChartRenderer = ({ resultSet }) => {
   return <Line type="area" data={data} options={options} />;
 };
 
+const PieChartRenderer = ({ resultSet }) => {
+  const data = {
+    labels: resultSet.categories().map((c) => c.x),
+    datasets: resultSet.series().map((s) => ({
+      label: s.title,
+      data: s.series.map((r) => r.value),
+      backgroundColor: COLORS_SERIES,
+      hoverBackgroundColor: COLORS_SERIES,
+    })),
+  };
+
+  return <Pie type="pie" data={data} options={commonOptions} />;
+};
+
 const TypeToChartComponent = {
   line: ({ resultSet }) => {
     return <LineChartRenderer resultSet={resultSet} />;
@@ -155,17 +169,7 @@ const TypeToChartComponent = {
     return <AreaChartRenderer resultSet={resultSet} />;
   },
   pie: ({ resultSet }) => {
-    const data = {
-      labels: resultSet.categories().map((c) => c.x),
-      datasets: resultSet.series().map((s) => ({
-        label: s.title,
-        data: s.series.map((r) => r.value),
-        backgroundColor: COLORS_SERIES,
-        hoverBackgroundColor: COLORS_SERIES,
-      })),
-    };
-
-    return <Pie type="pie" data={data} options={commonOptions} />;
+    return <PieChartRenderer resultSet={resultSet} />;
   },
 };
 export default TypeToChartComponent;

--- a/packages/chartjs-charts/scaffolding/src/components/ChartRenderer.js
+++ b/packages/chartjs-charts/scaffolding/src/components/ChartRenderer.js
@@ -50,7 +50,22 @@ const commonOptions = {
   },
 };
 
-const LineChartRenderer = ({ resultSet }) => {
+const useDrilldownCallback = ({ datasets, labels, onDrilldownRequested }) => {
+  return React.useCallback(
+    (elements) => {
+      if (elements.length <= 0) return;
+      const { datasetIndex, index } = elements[0];
+      const { yValues } = datasets[datasetIndex];
+      const xValues = [labels[index]];
+      if (typeof onDrilldownRequested === 'function') {
+        onDrilldownRequested(xValues, yValues);
+      }
+    },
+    [datasets, labels, onDrilldownRequested]
+  );
+};
+
+const LineChartRenderer = ({ resultSet, onDrilldownRequested }) => {
   const datasets = useDeepCompareMemo(
     () =>
       resultSet.series().map((s, index) => ({
@@ -72,10 +87,23 @@ const LineChartRenderer = ({ resultSet }) => {
     datasets,
   };
 
-  return <Line type="line" data={data} options={commonOptions} />;
+  const getElementAtEvent = useDrilldownCallback({
+    datasets: data.datasets,
+    labels: data.labels,
+    onDrilldownRequested,
+  });
+
+  return (
+    <Line
+      type="line"
+      data={data}
+      options={commonOptions}
+      getElementAtEvent={getElementAtEvent}
+    />
+  );
 };
 
-const BarChartRenderer = ({ resultSet, pivotConfig }) => {
+const BarChartRenderer = ({ resultSet, pivotConfig, onDrilldownRequested }) => {
   const datasets = useDeepCompareMemo(
     () =>
       resultSet.series().map((s, index) => ({
@@ -107,10 +135,24 @@ const BarChartRenderer = ({ resultSet, pivotConfig }) => {
       },
     },
   };
-  return <Bar type="bar" data={data} options={options} />;
+
+  const getElementAtEvent = useDrilldownCallback({
+    datasets: data.datasets,
+    labels: data.labels,
+    onDrilldownRequested,
+  });
+
+  return (
+    <Bar
+      type="bar"
+      data={data}
+      options={options}
+      getElementAtEvent={getElementAtEvent}
+    />
+  );
 };
 
-const AreaChartRenderer = ({ resultSet }) => {
+const AreaChartRenderer = ({ resultSet, onDrilldownRequested }) => {
   const datasets = useDeepCompareMemo(
     () =>
       resultSet.series().map((s, index) => ({
@@ -141,10 +183,23 @@ const AreaChartRenderer = ({ resultSet }) => {
     },
   };
 
-  return <Line type="area" data={data} options={options} />;
+  const getElementAtEvent = useDrilldownCallback({
+    datasets: data.datasets,
+    labels: data.labels,
+    onDrilldownRequested,
+  });
+
+  return (
+    <Line
+      type="area"
+      data={data}
+      options={options}
+      getElementAtEvent={getElementAtEvent}
+    />
+  );
 };
 
-const PieChartRenderer = ({ resultSet }) => {
+const PieChartRenderer = ({ resultSet, onDrilldownRequested }) => {
   const data = {
     labels: resultSet.categories().map((c) => c.x),
     datasets: resultSet.series().map((s) => ({
@@ -155,21 +210,55 @@ const PieChartRenderer = ({ resultSet }) => {
     })),
   };
 
-  return <Pie type="pie" data={data} options={commonOptions} />;
+  const getElementAtEvent = useDrilldownCallback({
+    datasets: data.datasets,
+    labels: data.labels,
+    onDrilldownRequested,
+  });
+
+  return (
+    <Pie
+      type="pie"
+      data={data}
+      options={commonOptions}
+      getElementAtEvent={getElementAtEvent}
+    />
+  );
 };
 
 const TypeToChartComponent = {
-  line: ({ resultSet }) => {
-    return <LineChartRenderer resultSet={resultSet} />;
+  line: ({ resultSet, onDrilldownRequested }) => {
+    return (
+      <LineChartRenderer
+        resultSet={resultSet}
+        onDrilldownRequested={onDrilldownRequested}
+      />
+    );
   },
-  bar: ({ resultSet, pivotConfig }) => {
-    return <BarChartRenderer resultSet={resultSet} pivotConfig={pivotConfig} />;
+  bar: ({ resultSet, pivotConfig, onDrilldownRequested }) => {
+    return (
+      <BarChartRenderer
+        resultSet={resultSet}
+        pivotConfig={pivotConfig}
+        onDrilldownRequested={onDrilldownRequested}
+      />
+    );
   },
-  area: ({ resultSet }) => {
-    return <AreaChartRenderer resultSet={resultSet} />;
+  area: ({ resultSet, onDrilldownRequested }) => {
+    return (
+      <AreaChartRenderer
+        resultSet={resultSet}
+        onDrilldownRequested={onDrilldownRequested}
+      />
+    );
   },
-  pie: ({ resultSet }) => {
-    return <PieChartRenderer resultSet={resultSet} />;
+  pie: ({ resultSet, onDrilldownRequested }) => {
+    return (
+      <PieChartRenderer
+        resultSet={resultSet}
+        onDrilldownRequested={onDrilldownRequested}
+      />
+    );
   },
 };
 export default TypeToChartComponent;

--- a/packages/chartjs-charts/scaffolding/src/components/ChartRenderer.js
+++ b/packages/chartjs-charts/scaffolding/src/components/ChartRenderer.js
@@ -50,7 +50,12 @@ const commonOptions = {
   },
 };
 
-const useDrilldownCallback = ({ datasets, labels, onDrilldownRequested }) => {
+const useDrilldownCallback = ({
+  datasets,
+  labels,
+  onDrilldownRequested,
+  pivotConfig,
+}) => {
   return React.useCallback(
     (elements) => {
       if (elements.length <= 0) return;
@@ -58,7 +63,7 @@ const useDrilldownCallback = ({ datasets, labels, onDrilldownRequested }) => {
       const { yValues } = datasets[datasetIndex];
       const xValues = [labels[index]];
       if (typeof onDrilldownRequested === 'function') {
-        onDrilldownRequested(xValues, yValues);
+        onDrilldownRequested({ xValues, yValues }, pivotConfig);
       }
     },
     [datasets, labels, onDrilldownRequested]
@@ -142,6 +147,7 @@ const BarChartRenderer = ({ resultSet, pivotConfig, onDrilldownRequested }) => {
     datasets: data.datasets,
     labels: data.labels,
     onDrilldownRequested,
+    pivotConfig,
   });
 
   return (

--- a/packages/chartjs-charts/scaffolding/src/components/ChartRenderer.js
+++ b/packages/chartjs-charts/scaffolding/src/components/ChartRenderer.js
@@ -71,6 +71,7 @@ const LineChartRenderer = ({ resultSet, onDrilldownRequested }) => {
       resultSet.series().map((s, index) => ({
         label: s.title,
         data: s.series.map((r) => r.value),
+        yValues: [s.key],
         borderColor: COLORS_SERIES[index],
         pointRadius: 1,
         tension: 0.1,
@@ -109,6 +110,7 @@ const BarChartRenderer = ({ resultSet, pivotConfig, onDrilldownRequested }) => {
       resultSet.series().map((s, index) => ({
         label: s.title,
         data: s.series.map((r) => r.value),
+        yValues: [s.key],
         backgroundColor: COLORS_SERIES[index],
         fill: false,
       })),
@@ -158,6 +160,7 @@ const AreaChartRenderer = ({ resultSet, onDrilldownRequested }) => {
       resultSet.series().map((s, index) => ({
         label: s.title,
         data: s.series.map((r) => r.value),
+        yValues: [s.key],
         pointRadius: 1,
         pointHoverRadius: 1,
         backgroundColor: PALE_COLORS_SERIES[index],
@@ -205,6 +208,7 @@ const PieChartRenderer = ({ resultSet, onDrilldownRequested }) => {
     datasets: resultSet.series().map((s) => ({
       label: s.title,
       data: s.series.map((r) => r.value),
+      yValues: [s.key],
       backgroundColor: COLORS_SERIES,
       hoverBackgroundColor: COLORS_SERIES,
     })),

--- a/packages/react-charts/scaffolding/src/ChartContainer.js
+++ b/packages/react-charts/scaffolding/src/ChartContainer.js
@@ -23,13 +23,14 @@ const ChartRenderer = ({
     query
   );
 
-  const handleQueryDrilldownRequest = (xValues, yValues) => {
+  const handleQueryDrilldownRequest = ({ xValues, yValues }, pivotConfig) => {
     if (typeof onQueryDrilldown === 'function') {
       onQueryDrilldown(
         resultSet.drillDown({
           xValues,
           yValues,
-        })
+        }),
+        pivotConfig
       );
     }
   };

--- a/packages/react-charts/scaffolding/src/ChartContainer.js
+++ b/packages/react-charts/scaffolding/src/ChartContainer.js
@@ -12,11 +12,27 @@ const ChartRenderer = ({
 }) => {
   const { forQuery } = window.parent.window['__cubejsPlayground'] || {};
 
-  const { onQueryStart, onQueryLoad, onQueryProgress } = forQuery(queryId);
+  const {
+    onQueryStart,
+    onQueryLoad,
+    onQueryProgress,
+    onQueryDrilldown,
+  } = forQuery(queryId);
 
   const { isLoading, error, resultSet, progress, refetch } = useCubeQuery(
     query
   );
+
+  const handleQueryDrilldownRequest = (xValues, yValues) => {
+    if (typeof onQueryDrilldown === 'function') {
+      onQueryDrilldown(
+        resultSet.drillDown({
+          xValues,
+          yValues,
+        })
+      );
+    }
+  };
 
   useDeepCompareEffect(() => {
     if (
@@ -51,7 +67,11 @@ const ChartRenderer = ({
     return null;
   }
 
-  return renderFunction({ resultSet, pivotConfig });
+  return renderFunction({
+    resultSet,
+    pivotConfig,
+    onDrilldownRequested: handleQueryDrilldownRequest,
+  });
 };
 
 const ChartContainer = ({


### PR DESCRIPTION
# Reason
Basically I am trying to support drilldowns in cubejs-playground.

Changes here are needed to handle click events on the chart.

# Technical description

1. Add click event handlers on chartjs charts
2. This click events prepares `xValues` and `yValues` needed by `resultSet.drillDown` function.
3. After preparing the values, they are lifted up to the parent component which is `ChartContainer.tsx` in `react-charts` package.
4. These values are caught by `handleQueryDrilldownRequest` in  `ChartContainer.tsx` and lifted up to parent window which is the playground window.
5. After that the cube.js/cubejs-playground will handle the rest of the functionality.

# Why lifting the drill down query up to the parent window
Because I wanna show a modal which will be super ugly if shown inside an iframe.

# Note
The merge request must be merged with the other merge request in cube.js repository [here](https://github.com/cube-js/cube.js/pull/3500).

# Demo

https://user-images.githubusercontent.com/15963779/135303179-613dc1be-07b0-4b80-9ae0-60ba74616be5.mp4


